### PR TITLE
Add first version with rate-limit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ go build
 envoy -c envoy_config.yaml
 ```
 
+- The `example.rego` policy defines a limit of 5 requests per second for the
+"/abc" path, but each user identified by the "user_id" header can only make 3
+requests per second. To test this, you'll need to start a server in 8080 or choose another one, but remember to change it in `envoy_config.yaml` as well. For testing purposes you can use: `python -m http.server 8080`. Now make requests to Envoy:
+    - `curl -v http://localhost:8000/abc -H "user_id:a"`. Authorized: total
+    (1/5), user_a (1/3), user_b (0/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:a"`. Authorized: total
+    (2/5), user_a (2/3), user_b (0/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:a"`. Authorized: total
+    (3/5), user_a (3/3), user_b (0/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:a"`. Limited: total (3/5),
+    **user_a (4/3)**, user_b (0/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:b"`. Authorized: total
+    (4/5), user_a (3/3), user_b (1/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:b"`. Authorized: total
+    (5/5), user_a (3/3), user_b (2/3).
+    - `curl -v http://localhost:8000/abc -H "user_id:b"`: Limited: **total
+    (6/5)**, user_a (3/3), user_b (3/3).

--- a/docs/rate_limiting.md
+++ b/docs/rate_limiting.md
@@ -1,0 +1,93 @@
+# Rate limiting examples
+
+Different limits for two paths. The rest are unlimited:
+
+```
+default allow = false
+default rate_limited = false
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    http_request.path == "/abc"
+    rate_limit({"by": {"path": http_request.path}, "count": 5, "seconds": 60})
+}
+
+rate_limited {
+    http_request.path == "/def"
+    rate_limit({"by": {"path": http_request.path}, "count": 2, "seconds": 60})
+}
+```
+
+
+Different limits for two methods. The rest are unlimited:
+
+```
+default allow = false
+default rate_limited = false
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    http_request.method == "GET"
+    rate_limit({"by": {"method": http_request.method}, "count": 5, "seconds": 60})
+}
+
+rate_limited {
+    http_request.method == "HEAD"
+    rate_limit({"by": {"path": http_request.method}, "count": 2, "seconds": 60})
+}
+```
+
+
+Limit by header. All the values have the same limit and denies if the header is not set:
+
+```
+default allow = false
+default rate_limited = false
+
+allow {
+    has_user_id
+    not rate_limited
+    update_limits_usage()
+}
+
+has_user_id {
+    http_request.headers["user_id"] != null
+}
+
+rate_limited {
+    rate_limit({"by": {"user_id": http_request.headers["user_id"]}, "count": 5, "seconds": 60})
+}
+```
+
+Use a generic limit of 5 rps for a path but limit some users to 3:
+
+```
+default allow = false
+default rate_limited = false
+
+limited_user_ids := [ "a", "b" ]
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    http_request.path == "/abc"
+    rate_limit({"by": {"path": http_request.path}, "count": 5, "seconds": 60})
+}
+
+rate_limited {
+    http_request.path == "/abc"
+    http_request.headers["user_id"] == limited_user_ids[_]
+    rate_limit({"by": {"path": http_request.path, "user_id": http_request.headers["user_id"]}, "count": 3, "seconds": 60})
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/envoyproxy/go-control-plane v0.9.2
 	github.com/open-policy-agent/opa v0.17.1
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.0.0-20181023235946-059132a15dd0
 	github.com/sirupsen/logrus v1.4.1
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8u
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/open-policy-agent/opa v0.17.1 h1:FchWeIevMohOKLM7oyFunUHEMp3gAOUCu+NNo/c6FjA=
 github.com/open-policy-agent/opa v0.17.1/go.mod h1:P0xUE/GQAAgnvV537GzA0Ikw4+icPELRT327QJPkaKY=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d h1:zapSxdmZYY6vJWXFKLQ+MkI+agc+HQyfrCGowDSHiKs=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/pkg/errors v0.0.0-20181023235946-059132a15dd0 h1:R+lX9nKwNd1n7UE5SQAyoorREvRn3aLF6ZndXBoIWqY=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	runtime.RegisterPlugin("envoy_ext_authz_grpc", Factory{})
 
 	threescale.RegisterThreeScaleQueries()
+	threescale.RegisterRateLimitQueries()
 
 	if err := cmd.RootCommand.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/threescale/limits_storage.go
+++ b/pkg/threescale/limits_storage.go
@@ -1,0 +1,38 @@
+package threescale
+
+import (
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+// For now, we use gocache to store the limits. In order to implement shared
+// limits between instances, we could use a DB like Redis.
+
+type LimitsStorage struct {
+	internalStorage *gocache.Cache
+}
+
+func newLimitsStorage() LimitsStorage {
+	goCache := gocache.New(gocache.NoExpiration, time.Minute)
+	return LimitsStorage{internalStorage: goCache}
+}
+
+func (storage *LimitsStorage) get(key string) (int, bool) {
+	val, exists := storage.internalStorage.Get(key)
+
+	if !exists {
+		return 0, false
+	}
+
+	return val.(int), exists
+}
+
+func (storage *LimitsStorage) setWithTTL(key string, value int, duration time.Duration) {
+	storage.internalStorage.Set(key, value, duration)
+}
+
+func (storage *LimitsStorage) decrement(key string, value int) error {
+	_, err := storage.internalStorage.DecrementInt(key, value)
+	return err
+}

--- a/pkg/threescale/rate_limit_queries.go
+++ b/pkg/threescale/rate_limit_queries.go
@@ -1,0 +1,168 @@
+package threescale
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/open-policy-agent/opa/topdown"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+)
+
+// There are two commands defined for rate limiting: "rate_limit" and
+// "update_limits_usage".
+// "rate_limit" defines a limit for some entity or combination of them (source
+// IP, user ID, request path, etc.) and checks whether the request should be
+// limited.
+// "update_limits_usage" updates all the rate-limit counters associated with the
+// request.
+// The counters cannot be updated in the "rate_limit" command because there
+// might be several limits that apply for a single request, and we want to
+// update the usage only when we are within the delimits defined for all of
+// them.
+// Ideally, we'd like to run "update_limits_usage" transparently, but for now,
+// we need to call it explicitly in the .rego after checking the limits.
+
+type opaLimit struct {
+	By      map[string]string
+	Count   int
+	Seconds int
+}
+
+// The string generated in this function should be unique per opaLimit.
+func (limit *opaLimit) key() (string, error) {
+	limitJSON, err := json.Marshal(&limit)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(limitJSON), nil
+}
+
+var storage = newLimitsStorage()
+
+const limitsCtxKey = "limits_to_apply"
+
+var rateLimitBuiltin = &ast.Builtin{
+	Name: "rate_limit",
+	Decl: types.NewFunction(types.Args(types.A), types.B),
+}
+
+// Returns true if limited, false otherwise. It does not update the counter used
+// to rate-limit. Instead, when within limits, the increase value is stored in
+// the context so it can be applied later. When rate-limited, it cleans the
+// limits in the context, because in that case, we want to make sure that no
+// updates are applied.
+func rateLimitBuiltinImpl(limitValue ast.Value, bctx topdown.BuiltinContext) (ast.Value, error) {
+	limit := opaLimit{}
+	err := ast.As(limitValue, &limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: there's a hardcoded count of 1, we might want to change this later
+	// and allow arbitrary updates on each request.
+	withinLimits, err := withinLimits(1, &limit)
+	if err != nil {
+		return nil, err
+	}
+
+	if withinLimits {
+		err := storeLimitUpdateInCtx(&limit, 1, bctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		removeLimitUpdates(bctx)
+	}
+
+	return ast.Boolean(!withinLimits), nil
+}
+
+var updateLimitsUsageBuiltin = &ast.Builtin{
+	Name: "update_limits_usage",
+	Decl: types.NewFunction(types.Args(), types.B),
+}
+
+// Updates the counters used to rate-limit with the values stored in the
+// context.
+func updateLimitsUsageBuiltinImpl(bctx topdown.BuiltinContext) (ast.Value, error) {
+	limits, exists := bctx.Cache.Get(limitsCtxKey)
+
+	if !exists || limits == nil {
+		return ast.Boolean(true), nil
+	}
+
+	for limitJSON, increaseBy := range limits.(map[string]int) {
+		limit := opaLimit{}
+		err := json.Unmarshal([]byte(limitJSON), &limit)
+		if err != nil {
+			return nil, err
+		}
+
+		err = updateUsage(increaseBy, &limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ast.Boolean(true), nil
+}
+
+// Returns true if the limit if we do not go over limits after adding count.
+// False otherwise.
+func withinLimits(count int, limit *opaLimit) (bool, error) {
+	key, err := limit.key()
+
+	if err != nil {
+		return false, err
+	}
+
+	currentVal, exists := storage.get(key)
+
+	if !exists {
+		return limit.Count-count >= 0, nil
+	}
+
+	return currentVal-count >= 0, nil
+}
+
+func updateUsage(count int, limit *opaLimit) error {
+	key, err := limit.key()
+	if err != nil {
+		return err
+	}
+
+	// TODO: The get + set if not exists should be done atomically
+	_, exists := storage.internalStorage.Get(key)
+	if !exists {
+		storage.internalStorage.Set(key, limit.Count-1, time.Duration(limit.Seconds)*time.Second)
+		return nil
+	}
+
+	return storage.decrement(key, count)
+}
+
+func storeLimitUpdateInCtx(limit *opaLimit, increaseBy int, bctx topdown.BuiltinContext) error {
+	val, exists := bctx.Cache.Get(limitsCtxKey)
+
+	if !exists || val == nil {
+		val = make(map[string]int)
+		bctx.Cache.Put(limitsCtxKey, val)
+	}
+
+	key, err := limit.key()
+	if err != nil {
+		return err
+	}
+
+	val.(map[string]int)[key] = increaseBy
+
+	return nil
+}
+
+func removeLimitUpdates(bctx topdown.BuiltinContext) {
+	bctx.Cache.Put(limitsCtxKey, nil)
+}

--- a/pkg/threescale/registerer.go
+++ b/pkg/threescale/registerer.go
@@ -1,11 +1,83 @@
 package threescale
 
 import (
+	"fmt"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/topdown/builtins"
 )
 
 func RegisterThreeScaleQueries() {
 	ast.RegisterBuiltin(PrintPathBuiltin)
 	topdown.RegisterFunctionalBuiltin1(PrintPathBuiltin.Name, PrintPathImpl)
+}
+
+func RegisterRateLimitQueries() {
+	registerRateLimitBuiltIn()
+	registerUpdateLimitsUsageBuiltin()
+}
+
+func registerRateLimitBuiltIn() {
+	ast.RegisterBuiltin(rateLimitBuiltin)
+
+	name := rateLimitBuiltin.Name
+	funcImpl := rateLimitBuiltinImpl
+
+	// We can't use the helpers provided by OPA directly because we need to pass
+	// the builtinContext as a param. We use that to store the counters that
+	// need to be updated at the end of the query.
+	builtinFunc := func(bctx topdown.BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := funcImpl(args[0].Value, bctx)
+		if err == nil {
+			return iter(ast.NewTerm(result))
+		}
+		if _, empty := err.(topdown.BuiltinEmpty); empty {
+			return nil
+		}
+		return handleBuiltinErr(name, bctx.Location, err)
+	}
+
+	topdown.RegisterBuiltinFunc(name, builtinFunc)
+}
+
+func registerUpdateLimitsUsageBuiltin() {
+	ast.RegisterBuiltin(updateLimitsUsageBuiltin)
+
+	name := updateLimitsUsageBuiltin.Name
+	funcImpl := updateLimitsUsageBuiltinImpl
+
+	builtinFunc := func(bctx topdown.BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
+		result, err := funcImpl(bctx)
+		if err == nil {
+			return iter(ast.NewTerm(result))
+		}
+		if _, empty := err.(topdown.BuiltinEmpty); empty {
+			return nil
+		}
+		return handleBuiltinErr(name, bctx.Location, err)
+	}
+
+	topdown.RegisterBuiltinFunc(name, builtinFunc)
+}
+
+// This is copy-pasted from the OPA library. It's a private func that we need to
+// define the rate-limit commands.
+func handleBuiltinErr(name string, loc *ast.Location, err error) error {
+	switch err := err.(type) {
+	case topdown.BuiltinEmpty:
+		return nil
+	case builtins.ErrOperand:
+		return &topdown.Error{
+			Code:     topdown.TypeErr,
+			Message:  fmt.Sprintf("%v: %v", string(name), err.Error()),
+			Location: loc,
+		}
+	default:
+		return &topdown.Error{
+			Code:     topdown.BuiltinErr,
+			Message:  fmt.Sprintf("%v: %v", string(name), err.Error()),
+			Location: loc,
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a first version that extends OPA with a couple of commands to rate-limit requests.

There are two new commands: `rate_limit` and `update_limits_usage`:
- `rate_limit` defines a limit for some entity or combination of them (source IP, user ID, request path, etc.) and checks whether the request should be limited.
- `update_limits_usage` updates all the rate-limit counters associated with the request. The counters cannot be updated in the `rate_limit` command because there might be several limits that apply for a single request, and we want to update the usage only when we are within the delimits defined for all of them.

Ideally, we'd like to run "update_limits_usage" transparently, but for now, we need to call it explicitly in the .rego after checking the limits.

