### PR TITLE
Add first test

### DIFF
--- a/tests/rate_limit_two_paths.rego
+++ b/tests/rate_limit_two_paths.rego
@@ -1,0 +1,23 @@
+package envoy.authz
+
+# Different limits for two paths. The rest are unlimited:
+
+import input.attributes.request.http as http_request
+
+default allow = false
+default rate_limited = false
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    http_request.path == "/abc"
+    rate_limit({"by": {"path": http_request.path}, "count": 2, "seconds": 60})
+}
+
+rate_limited {
+    http_request.path == "/def"
+    rate_limit({"by": {"path": http_request.path}, "count": 1, "seconds": 60})
+}

--- a/tests/rate_limit_two_paths_test.rego
+++ b/tests/rate_limit_two_paths_test.rego
@@ -1,0 +1,23 @@
+package envoy.authz
+
+import input.attributes.request.http as http_request
+
+test_path_abc_has_limit_of_2_rpmin {
+    allow with http_request as {"path": "/abc" }
+    allow with http_request as {"path": "/abc" }
+    not allow with http_request as {"path": "/abc" }
+}
+
+test_path_def_has_limit_of_1_rpmin {
+    allow with http_request as {"path": "/def" }
+    not allow with http_request as {"path": "/def" }
+}
+
+test_rest_of_paths_unlimited {
+    # To test "unlimited", just make more reqs than the sum of the two other
+    # limits to be sure.
+    allow with http_request as {"path": "/" }
+    allow with http_request as {"path": "/" }
+    allow with http_request as {"path": "/" }
+    allow with http_request as {"path": "/" }
+}


### PR DESCRIPTION
Added just as an example of how I think we should test our custom commands.

@jmprusi If you agree with this, I'll add more tests later. The only problem I see is that our tests rely on state (rate-limit counters), so we'll need to write a wrapper on top to make sure to reset it between tests.

To run the tests: `./3scale-opa test tests/ -v`