### PR TITLE
Test examples

### DIFF
--- a/docs/rate_limiting.md
+++ b/docs/rate_limiting.md
@@ -55,8 +55,8 @@ default allow = false
 default rate_limited = false
 
 # Define to arrays of IPs, the restricted and the unrestricted.
-non_restricted_ips = ['127.0.0.1','2.2.2.2']
-restricted_ips = ['172.16.0.1']
+non_restricted_ips = {"127.0.0.1","2.2.2.2"}
+restricted_ips = {"172.16.0.1"}
 
 # We allow the request to go through only if is "not" rate_limited.
 # All the conditions inside allow are treated as "AND".
@@ -70,20 +70,20 @@ allow {
 
 # If the source address is in the non_restricted_ip list, we check for a 200r/60s limit.
 rate_limited {
-    req.source.address == non_restricted_ips[_]
+    non_restricted_ips[req.source.address]
     rate_limit({"by": {"client_ip": req.source.address}, "count": 200, "seconds": 60})
 }
 
 # If the source address is in the restricted list, we check for a 20r/60s limit.
 rate_limited {
-    req.source.address == restricted_ips[_]
+    restricted_ips[req.source.address]
     rate_limit({"by": {"client_ip": req.source.address}, "count": 20, "seconds": 60})
 }
 
 # If the source address is not in either list, we check for a 100r/60s limit.
 rate_limited {
-    req.source.address != restricted_ips[_]
-    req.source.address != non_restricted_ips[_]
+    not non_restricted_ips[req.source.address]
+    not restricted_ips[req.source.address]
     rate_limit({"by": {"client_ip": req.source.address}, "count": 100, "seconds": 60})
 }
 ```

--- a/tests/rate_limit_by_header.rego
+++ b/tests/rate_limit_by_header.rego
@@ -1,0 +1,23 @@
+package threescale.tests.rate_limit_by_header
+
+# Limit by the value of the "user_id" header. All the values have the same limit
+# associated. Denies when the header is not set:
+
+import input.attributes.request.http as http_request
+
+default allow = false
+default rate_limited = false
+
+allow {
+    has_user_id
+    not rate_limited
+    update_limits_usage()
+}
+
+has_user_id {
+    http_request.headers["user_id"] != null
+}
+
+rate_limited {
+    rate_limit({"by": {"user_id": http_request.headers["user_id"]}, "count": 2, "seconds": 60})
+}

--- a/tests/rate_limit_by_header_test.rego
+++ b/tests/rate_limit_by_header_test.rego
@@ -1,0 +1,17 @@
+package threescale.tests.rate_limit_by_header
+
+import input.attributes.request.http as http_request
+
+test_limit_is_per_user_id_header {
+    allow with http_request as { "headers": { "user_id": "1" } }
+    allow with http_request as { "headers": { "user_id": "1" } }
+    not allow with http_request as { "headers": { "user_id": "1" } }
+
+    allow with http_request as { "headers": { "user_id": "2" } }
+    allow with http_request as { "headers": { "user_id": "2" } }
+    not allow with http_request as { "headers": { "user_id": "2" } }
+}
+
+test_without_user_id_header {
+    not allow with http_request as { "headers": {} }
+}

--- a/tests/rate_limit_by_ip.rego
+++ b/tests/rate_limit_by_ip.rego
@@ -1,0 +1,35 @@
+package threescale.tests.rate_limit_by_ip
+
+# Limit based on client ip addresses the traffic to some servers:
+#   * Global Limit by IP of 2 r/min.
+#   * A set of IPs can do up to 3 r/min instead of 2 r/min.
+#   * A set of IPs can only do 1 r/min as those are more restricted.
+
+import input.attributes as req
+
+default allow = false
+default rate_limited = false
+
+less_restricted_ips = {"1.1.1.1", "2.2.2.2"}
+restricted_ips = {"3.3.3.3", "4.4.4.4"}
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    less_restricted_ips[req.source.address]
+    rate_limit({"by": {"client_ip": req.source.address}, "count": 3, "seconds": 60})
+}
+
+rate_limited {
+    restricted_ips[req.source.address]
+    rate_limit({"by": {"client_ip": req.source.address}, "count": 1, "seconds": 60})
+}
+
+rate_limited {
+    not less_restricted_ips[req.source.address]
+    not restricted_ips[req.source.address]
+    rate_limit({"by": {"client_ip": req.source.address}, "count": 2, "seconds": 60})
+}

--- a/tests/rate_limit_by_ip_test.rego
+++ b/tests/rate_limit_by_ip_test.rego
@@ -1,0 +1,29 @@
+package threescale.tests.rate_limit_by_ip
+
+import input.attributes as req
+
+test_restricted_ips_have_a_limit_of_1_rpm {
+    allow with req as { "source": { "address": "3.3.3.3" } }
+    not allow with req as { "source": { "address": "3.3.3.3" } }
+
+    allow with req as { "source": { "address": "4.4.4.4" } }
+    not allow with req as { "source": { "address": "4.4.4.4" } }
+}
+
+test_less_restricted_ips_have_a_limit_of_3_rpm {
+    allow with req as { "source": { "address": "1.1.1.1" } }
+    allow with req as { "source": { "address": "1.1.1.1" } }
+    allow with req as { "source": { "address": "1.1.1.1" } }
+    not allow with req as { "source": { "address": "1.1.1.1" } }
+
+    allow with req as { "source": { "address": "2.2.2.2" } }
+    allow with req as { "source": { "address": "2.2.2.2" } }
+    allow with req as { "source": { "address": "2.2.2.2" } }
+    not allow with req as { "source": { "address": "2.2.2.2" } }
+}
+
+test_rest_of_ips_have_a_limit_of_2_rpm {
+    allow with req as { "source": { "address": "5.5.5.5" } }
+    allow with req as { "source": { "address": "5.5.5.5" } }
+    not allow with req as { "source": { "address": "5.5.5.5" } }
+}

--- a/tests/rate_limit_two_methods.rego
+++ b/tests/rate_limit_two_methods.rego
@@ -1,0 +1,23 @@
+package threescale.tests.rate_limit_two_methods
+
+# Different limits for two HTTP methods. The rest are unlimited:
+
+import input.attributes.request.http as http_request
+
+default allow = false
+default rate_limited = false
+
+allow {
+    not rate_limited
+    update_limits_usage()
+}
+
+rate_limited {
+    http_request.method == "GET"
+    rate_limit({"by": {"method": http_request.method}, "count": 2, "seconds": 60})
+}
+
+rate_limited {
+    http_request.method == "POST"
+    rate_limit({"by": {"path": http_request.method}, "count": 1, "seconds": 60})
+}

--- a/tests/rate_limit_two_methods_test.rego
+++ b/tests/rate_limit_two_methods_test.rego
@@ -1,0 +1,25 @@
+package threescale.tests.rate_limit_two_methods
+
+import input.attributes.request.http as http_request
+
+test_get_has_a_limit_of_two_rpmin {
+    test_request := { "method": "GET" }
+    allow with http_request as test_request
+    allow with http_request as test_request
+    not allow with http_request as test_request
+}
+
+test_post_has_a_limit_of_one_rpmin {
+    test_request := { "method": "POST" }
+    allow with http_request as test_request
+    not allow with http_request as test_request
+}
+
+test_rest_of_methods_are_unlimited {
+    # To test "unlimited", just make more reqs than the sum of the two other
+    # limits to be sure.
+    test_request := { "method": "HEAD" }
+    allow with http_request as test_request
+    allow with http_request as test_request
+    allow with http_request as test_request
+}

--- a/tests/rate_limit_two_paths.rego
+++ b/tests/rate_limit_two_paths.rego
@@ -1,4 +1,4 @@
-package envoy.authz
+package threescale.tests.rate_limit_two_paths
 
 # Different limits for two paths. The rest are unlimited:
 

--- a/tests/rate_limit_two_paths_test.rego
+++ b/tests/rate_limit_two_paths_test.rego
@@ -1,4 +1,4 @@
-package envoy.authz
+package threescale.tests.rate_limit_two_paths
 
 import input.attributes.request.http as http_request
 

--- a/tests/rate_limit_two_paths_test.rego
+++ b/tests/rate_limit_two_paths_test.rego
@@ -3,21 +3,24 @@ package threescale.tests.rate_limit_two_paths
 import input.attributes.request.http as http_request
 
 test_path_abc_has_limit_of_2_rpmin {
-    allow with http_request as {"path": "/abc" }
-    allow with http_request as {"path": "/abc" }
-    not allow with http_request as {"path": "/abc" }
+    test_request := { "path": "/abc"}
+    allow with http_request as test_request
+    allow with http_request as test_request
+    not allow with http_request as test_request
 }
 
 test_path_def_has_limit_of_1_rpmin {
-    allow with http_request as {"path": "/def" }
-    not allow with http_request as {"path": "/def" }
+    test_request := { "path": "/def" }
+    allow with http_request as test_request
+    not allow with http_request as test_request
 }
 
 test_rest_of_paths_unlimited {
     # To test "unlimited", just make more reqs than the sum of the two other
     # limits to be sure.
-    allow with http_request as {"path": "/" }
-    allow with http_request as {"path": "/" }
-    allow with http_request as {"path": "/" }
-    allow with http_request as {"path": "/" }
+    test_request := { "path": "/" }
+    allow with http_request as test_request
+    allow with http_request as test_request
+    allow with http_request as test_request
+    allow with http_request as test_request
 }


### PR DESCRIPTION
Adds tests for all the examples that we have in `docs/rate_limiting.md`.
It also fixes the example that shows how to rate-limit by IP.