### PR TITLE
Add 3scale integration

### DIFF
--- a/3scale.rego
+++ b/3scale.rego
@@ -1,0 +1,9 @@
+package envoy.authz
+
+import input.attributes.request.http as http_request
+
+default allow = false
+
+allow {
+	authorize_with_3scale(input)
+}

--- a/envoy_config.yaml
+++ b/envoy_config.yaml
@@ -33,7 +33,7 @@ static_resources:
                         google_grpc:
                           target_uri: 127.0.0.1:9191
                           stat_prefix: ext_authz
-                        timeout: 0.5s
+                        timeout: 3s
                   - name: envoy.router
                     typed_config: {}
   clusters:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/3scale/3scale-opa
 go 1.13
 
 require (
+	github.com/3scale/3scale-go-client v0.3.0
+	github.com/3scale/3scale-porta-go-client v0.0.3
 	github.com/envoyproxy/go-control-plane v0.9.2
 	github.com/open-policy-agent/opa v0.17.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/3scale/3scale-go-client v0.3.0 h1:ThsL1ZsjAjzMqpruVG8HyfnXVrfS9ZmIMHwJcMnupNY=
+github.com/3scale/3scale-go-client v0.3.0/go.mod h1:mIpZ1swgfSBVN7JqvxtY0AC9QaLHmhGvGsP9P71ZilQ=
+github.com/3scale/3scale-porta-go-client v0.0.3 h1:/jcEnBQqBDuJYQKvvmKUw6c4LoF4PWq57EAD4q6HiJ8=
+github.com/3scale/3scale-porta-go-client v0.0.3/go.mod h1:eXz9JDFNrbJRqJkDs39bMxO+m/L5pz51JMof3A8jQ1k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.3 h1:wS8NNaIgtzapuArKIAjsyXtEN/IUjQkbw90xszUdS40=

--- a/pkg/threescale/registerer.go
+++ b/pkg/threescale/registerer.go
@@ -9,7 +9,8 @@ import (
 )
 
 func RegisterThreeScaleQueries() {
-	// Add here queries for 3scale integration
+	ast.RegisterBuiltin(ThreescaleAuthrepBuiltin)
+	topdown.RegisterFunctionalBuiltin1(ThreescaleAuthrepBuiltin.Name, AuthrepWithThreescaleImpl)
 }
 
 func RegisterRateLimitQueries() {

--- a/pkg/threescale/request.go
+++ b/pkg/threescale/request.go
@@ -1,5 +1,7 @@
 package threescale
 
+import "strings"
+
 // The Input struct is defined by the "opa-istio-plugin":
 // https://github.com/open-policy-agent/opa-istio-plugin#example-input
 
@@ -8,6 +10,23 @@ type Input struct {
 	ParsedQuery ParsedQuery `json:"parsed_query"`
 	ParsedBody  ParsedBody  `json:"parsed_body"`
 	Attributes  Attributes  `json:"attributes"`
+}
+
+func (input *Input) queryArgs() map[string]string {
+	res := make(map[string]string)
+
+	splittedPath := strings.Split(input.Attributes.Request.HTTP.Path, "?")
+
+	if len(splittedPath) == 1 {
+		return res
+	}
+
+	for _, argString := range strings.Split(splittedPath[1], "&") {
+		splitted := strings.Split(argString, "=")
+		res[splitted[0]] = splitted[1]
+	}
+
+	return res
 }
 
 type Attributes struct {

--- a/pkg/threescale/threescale_authrep_query.go
+++ b/pkg/threescale/threescale_authrep_query.go
@@ -1,0 +1,180 @@
+package threescale
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/3scale/3scale-go-client/threescale"
+
+	threescaleAPI "github.com/3scale/3scale-go-client/threescale/api"
+	apisonator "github.com/3scale/3scale-go-client/threescale/http"
+	porta "github.com/3scale/3scale-porta-go-client/client"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+)
+
+const (
+	adminPortalEnv         = "THREESCALE_ADMIN_PORTAL"
+	accessTokenEnv         = "THREESCALE_ACCESS_TOKEN"
+	serviceIdEnv           = "THREESCALE_SERVICE_ID"
+	proxyConfigEnvironment = "production"
+	adminPortalScheme      = "https"
+	adminPortalPort        = 443
+)
+
+var ThreescaleAuthrepBuiltin = &ast.Builtin{
+	Name: "authorize_with_3scale",
+	Decl: types.NewFunction(types.Args(types.A), types.B),
+}
+
+func AuthrepWithThreescaleImpl(httpRequest ast.Value) (ast.Value, error) {
+	// TODO: avoid instantiating the clients on every request
+	apisonatorClient, err := apisonator.NewDefaultClient()
+	if err != nil {
+		return nil, err
+	}
+
+	adminPortalHost := os.Getenv(adminPortalEnv)
+	if adminPortalHost == "" {
+		return nil, fmt.Errorf("admin portal not set")
+	}
+	adminPortal, err := porta.NewAdminPortal(
+		adminPortalScheme, adminPortalHost, adminPortalPort,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken := os.Getenv(accessTokenEnv)
+	if accessToken == "" {
+		return nil, fmt.Errorf("access token not set")
+	}
+
+	service := serviceFromEnv()
+	if service == "" {
+		return ast.Boolean(false), fmt.Errorf("service ID not found")
+	}
+
+	portaClient := porta.NewThreeScale(adminPortal, accessToken, nil)
+	proxyConfig, err := portaClient.GetLatestProxyConfig(string(service), proxyConfigEnvironment)
+	if err != nil {
+		return nil, err
+	}
+
+	request := Input{}
+	_ = json.Unmarshal([]byte(httpRequest.String()), &request)
+
+	clientAuth := clientAuthFromProxyConfig(&proxyConfig.ProxyConfig)
+	if clientAuth == nil {
+		return ast.Boolean(false), fmt.Errorf("service credentials not found")
+	}
+
+	appCreds := appCredsFromRequest(&request)
+	if appCreds == nil {
+		return ast.Boolean(false), fmt.Errorf("app credentials not found")
+	}
+
+	usage, err := usageFromMatchedRules(
+		request.Attributes.Request.HTTP.Path,
+		proxyConfig.ProxyConfig.Content.Proxy.ProxyRules,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// If there are no matches, it means that request to the request path are
+	// not authorized
+	if len(usage) == 0 {
+		return ast.Boolean(false), nil
+	}
+
+	threescaleRequest := threescale.Request{
+		Auth:    *clientAuth,
+		Service: service,
+		Transactions: []threescaleAPI.Transaction{
+			{
+				Metrics: usage,
+				Params:  *appCreds,
+			},
+		},
+	}
+
+	resp, err := apisonatorClient.AuthRep(threescaleRequest)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.Boolean(resp.Success()), nil
+}
+
+func clientAuthFromProxyConfig(proxyConfig *porta.ProxyConfig) *threescaleAPI.ClientAuth {
+	authType := proxyConfig.Content.BackendAuthenticationType
+	authVal := proxyConfig.Content.BackendAuthenticationValue
+
+	return &threescaleAPI.ClientAuth{
+		Type:  threescaleAPI.AuthType(authType),
+		Value: authVal,
+	}
+}
+
+func serviceFromEnv() threescaleAPI.Service {
+	serviceId := os.Getenv(serviceIdEnv)
+	if serviceId == "" {
+		return ""
+	}
+
+	return threescaleAPI.Service(serviceId)
+}
+
+func usageFromMatchedRules(path string, rules []porta.ProxyRule) (threescaleAPI.Metrics, error) {
+	res := threescaleAPI.Metrics(make(map[string]int))
+
+	for _, rule := range rules {
+		// TODO: There are probably some pattern for which this does not work.
+		regex, err := regexp.Compile(rule.Pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		if regex.Match([]byte(path)) {
+			res[rule.MetricSystemName] += int(rule.Delta)
+		}
+	}
+
+	return res, nil
+}
+
+func appCredsFromRequest(request *Input) *threescaleAPI.Params {
+	userKey := userKeyFromRequest(request)
+
+	if userKey != "" {
+		return &threescaleAPI.Params{UserKey: userKey}
+	}
+
+	appId, appKey := appIdAndKeyFromRequest(request)
+
+	if appId != "" && appKey != "" {
+		return &threescaleAPI.Params{
+			AppID:  appId,
+			AppKey: appKey,
+		}
+	}
+
+	return nil
+}
+
+// Note: the location of the user key is configurable in 3scale. It can be in
+// any header or query argument. For now we'll assume that if specified, it is
+// in the "user_key" query arg.
+func userKeyFromRequest(request *Input) string {
+	return request.queryArgs()["user_key"]
+}
+
+// Note: same assumption as in userKeyFromRequest() for now.
+func appIdAndKeyFromRequest(request *Input) (appID string, appKey string) {
+	args := request.queryArgs()
+	return args["app_id"], args["app_key"]
+}


### PR DESCRIPTION
For now it's a simple integration. It adds a new command that downloads the proxy configuration from Porta and then, makes an "authrep" call to apisonator with the usage resulting from matching the path with the mapping rules defined.

Using it it's very simple:
```rego
package envoy.authz

import input.attributes.request.http as http_request

default allow = false

allow {
	authorize_with_3scale(input)
}
```

It needs a few ENVs set: `THREESCALE_ADMIN_PORTAL`, `THREESCALE_ACCESS_TOKEN`, and `THREESCALE_SERVICE_ID`. I think this is good for now to show that it works. In the future, we'll think about alternative ways to extract this data.

The implementation is not efficient. In my next PR I'll add a cache for Porta configs.