### PR TITLE
Add cache for Porta configs

### DIFF
--- a/envoy_config.yaml
+++ b/envoy_config.yaml
@@ -33,7 +33,7 @@ static_resources:
                         google_grpc:
                           target_uri: 127.0.0.1:9191
                           stat_prefix: ext_authz
-                        timeout: 3s
+                        timeout: 5s
                   - name: envoy.router
                     typed_config: {}
   clusters:

--- a/pkg/threescale/porta_configs_cache.go
+++ b/pkg/threescale/porta_configs_cache.go
@@ -1,0 +1,42 @@
+package threescale
+
+import (
+	"time"
+
+	porta "github.com/3scale/3scale-porta-go-client/client"
+	gocache "github.com/patrickmn/go-cache"
+)
+
+const (
+	ttl             = time.Minute
+	cleanupInterval = 5 * time.Minute
+)
+
+type PortaConfigsCache struct {
+	internalStorage *gocache.Cache
+}
+
+func newPortaConfigsCache() PortaConfigsCache {
+	goCache := gocache.New(ttl, cleanupInterval)
+	return PortaConfigsCache{internalStorage: goCache}
+}
+
+func (cache *PortaConfigsCache) get(serviceId string, environment string) (*porta.ProxyConfig, bool) {
+	config, exists := cache.internalStorage.Get(key(serviceId, environment))
+
+	if !exists {
+		return nil, false
+	}
+
+	return config.(*porta.ProxyConfig), exists
+}
+
+func (cache *PortaConfigsCache) set(serviceId string, environment string, config *porta.ProxyConfig) {
+	cache.internalStorage.Set(
+		key(serviceId, environment), config, gocache.DefaultExpiration,
+	)
+}
+
+func key(serviceId string, environment string) string {
+	return serviceId + "/" + environment
+}

--- a/pkg/threescale/threescale_authrep_query.go
+++ b/pkg/threescale/threescale_authrep_query.go
@@ -29,44 +29,23 @@ var ThreescaleAuthrepBuiltin = &ast.Builtin{
 	Decl: types.NewFunction(types.Args(types.A), types.B),
 }
 
+var portaConfigsCache = newPortaConfigsCache()
+
 func AuthrepWithThreescaleImpl(httpRequest ast.Value) (ast.Value, error) {
-	// TODO: avoid instantiating the clients on every request
-	apisonatorClient, err := apisonator.NewDefaultClient()
-	if err != nil {
-		return nil, err
-	}
-
-	adminPortalHost := os.Getenv(adminPortalEnv)
-	if adminPortalHost == "" {
-		return nil, fmt.Errorf("admin portal not set")
-	}
-	adminPortal, err := porta.NewAdminPortal(
-		adminPortalScheme, adminPortalHost, adminPortalPort,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	accessToken := os.Getenv(accessTokenEnv)
-	if accessToken == "" {
-		return nil, fmt.Errorf("access token not set")
-	}
-
 	service := serviceFromEnv()
 	if service == "" {
-		return ast.Boolean(false), fmt.Errorf("service ID not found")
+		return nil, fmt.Errorf("service ID not found")
 	}
 
-	portaClient := porta.NewThreeScale(adminPortal, accessToken, nil)
-	proxyConfig, err := portaClient.GetLatestProxyConfig(string(service), proxyConfigEnvironment)
+	proxyConfig, err := proxyConfig(string(service), proxyConfigEnvironment)
 	if err != nil {
-		return nil, err
+		return ast.Boolean(false), err
 	}
 
 	request := Input{}
 	_ = json.Unmarshal([]byte(httpRequest.String()), &request)
 
-	clientAuth := clientAuthFromProxyConfig(&proxyConfig.ProxyConfig)
+	clientAuth := clientAuthFromProxyConfig(proxyConfig)
 	if clientAuth == nil {
 		return ast.Boolean(false), fmt.Errorf("service credentials not found")
 	}
@@ -78,7 +57,7 @@ func AuthrepWithThreescaleImpl(httpRequest ast.Value) (ast.Value, error) {
 
 	usage, err := usageFromMatchedRules(
 		request.Attributes.Request.HTTP.Path,
-		proxyConfig.ProxyConfig.Content.Proxy.ProxyRules,
+		proxyConfig.Content.Proxy.ProxyRules,
 	)
 	if err != nil {
 		return nil, err
@@ -101,6 +80,11 @@ func AuthrepWithThreescaleImpl(httpRequest ast.Value) (ast.Value, error) {
 		},
 	}
 
+	// TODO: avoid instantiating client on every request
+	apisonatorClient, err := apisonator.NewDefaultClient()
+	if err != nil {
+		return nil, err
+	}
 	resp, err := apisonatorClient.AuthRep(threescaleRequest)
 
 	if err != nil {
@@ -108,6 +92,39 @@ func AuthrepWithThreescaleImpl(httpRequest ast.Value) (ast.Value, error) {
 	}
 
 	return ast.Boolean(resp.Success()), nil
+}
+
+func proxyConfig(serviceId string, environment string) (*porta.ProxyConfig, error) {
+	cachedProxyConfig, exists := portaConfigsCache.get(serviceId, environment)
+	if exists {
+		return cachedProxyConfig, nil
+	}
+
+	adminPortalHost := os.Getenv(adminPortalEnv)
+	if adminPortalHost == "" {
+		return nil, fmt.Errorf("admin portal not set")
+	}
+	adminPortal, err := porta.NewAdminPortal(
+		adminPortalScheme, adminPortalHost, adminPortalPort,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken := os.Getenv(accessTokenEnv)
+	if accessToken == "" {
+		return nil, fmt.Errorf("access token not set")
+	}
+
+	portaClient := porta.NewThreeScale(adminPortal, accessToken, nil)
+	proxyConfig, err := portaClient.GetLatestProxyConfig(serviceId, proxyConfigEnvironment)
+	if err != nil {
+		return nil, err
+	}
+
+	portaConfigsCache.set(serviceId, environment, &proxyConfig.ProxyConfig)
+
+	return &proxyConfig.ProxyConfig, nil
 }
 
 func clientAuthFromProxyConfig(proxyConfig *porta.ProxyConfig) *threescaleAPI.ClientAuth {


### PR DESCRIPTION
This PR adds a simple cache for Porta proxy configs. Note that when the proxy config is not cached, it will be fetched from Porta in request time, which can be slow. We can optimize this later, for example, we could start a separate goroutine that refreshes the config in background.