### PR TITLE
Use atomic "set if not exists" in rate-limit query

### DIFF
--- a/pkg/threescale/limits_storage.go
+++ b/pkg/threescale/limits_storage.go
@@ -28,8 +28,10 @@ func (storage *LimitsStorage) get(key string) (int, bool) {
 	return val.(int), exists
 }
 
-func (storage *LimitsStorage) setWithTTL(key string, value int, duration time.Duration) {
-	storage.internalStorage.Set(key, value, duration)
+// Returns true if the key has been created. False otherwise.
+func (storage *LimitsStorage) create(key string, value int, duration time.Duration) bool {
+	alreadyExistsErr := storage.internalStorage.Add(key, value, duration)
+	return alreadyExistsErr == nil
 }
 
 func (storage *LimitsStorage) decrement(key string, value int) error {

--- a/pkg/threescale/rate_limit_queries.go
+++ b/pkg/threescale/rate_limit_queries.go
@@ -135,10 +135,9 @@ func updateUsage(count int, limit *opaLimit) error {
 		return err
 	}
 
-	// TODO: The get + set if not exists should be done atomically
-	_, exists := storage.internalStorage.Get(key)
-	if !exists {
-		storage.internalStorage.Set(key, limit.Count-1, time.Duration(limit.Seconds)*time.Second)
+	created := storage.create(key, limit.Count-1, time.Duration(limit.Seconds)*time.Second)
+
+	if created { // Already initialized with updated counter
 		return nil
 	}
 


### PR DESCRIPTION
Addresses a minor pending `TODO`.
Uses an atomic "set if not exists" in the rate-limit query.