### PR TITLE
Organize code into packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/3scale/kiper/pkg/queries"
+
 	"github.com/open-policy-agent/opa/runtime"
 
 	"github.com/3scale/kiper/internal/istio_plugin"
-	"github.com/3scale/kiper/pkg/threescale"
 	"github.com/open-policy-agent/opa/cmd"
 	"github.com/open-policy-agent/opa/plugins"
 )
@@ -29,8 +30,8 @@ func main() {
 	runtime.RegisterPlugin("envoy.ext_authz.grpc", Factory{}) // for backwards compatibility
 	runtime.RegisterPlugin("envoy_ext_authz_grpc", Factory{})
 
-	threescale.RegisterThreeScaleQueries()
-	threescale.RegisterRateLimitQueries()
+	queries.RegisterThreeScaleQueries()
+	queries.RegisterRateLimitQueries()
 
 	if err := cmd.RootCommand.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/queries/registerer.go
+++ b/pkg/queries/registerer.go
@@ -1,7 +1,11 @@
-package threescale
+package queries
 
 import (
 	"fmt"
+
+	"github.com/3scale/kiper/pkg/ratelimit"
+
+	"github.com/3scale/kiper/pkg/threescale"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown"
@@ -9,8 +13,8 @@ import (
 )
 
 func RegisterThreeScaleQueries() {
-	ast.RegisterBuiltin(ThreescaleAuthrepBuiltin)
-	topdown.RegisterFunctionalBuiltin1(ThreescaleAuthrepBuiltin.Name, AuthrepWithThreescaleImpl)
+	ast.RegisterBuiltin(threescale.ThreescaleAuthrepBuiltin)
+	topdown.RegisterFunctionalBuiltin1(threescale.ThreescaleAuthrepBuiltin.Name, threescale.AuthrepWithThreescaleImpl)
 }
 
 func RegisterRateLimitQueries() {
@@ -19,10 +23,10 @@ func RegisterRateLimitQueries() {
 }
 
 func registerRateLimitBuiltIn() {
-	ast.RegisterBuiltin(rateLimitBuiltin)
+	ast.RegisterBuiltin(ratelimit.RateLimitBuiltin)
 
-	name := rateLimitBuiltin.Name
-	funcImpl := rateLimitBuiltinImpl
+	name := ratelimit.RateLimitBuiltin.Name
+	funcImpl := ratelimit.RateLimitBuiltinImpl
 
 	// We can't use the helpers provided by OPA directly because we need to pass
 	// the builtinContext as a param. We use that to store the counters that
@@ -42,10 +46,10 @@ func registerRateLimitBuiltIn() {
 }
 
 func registerUpdateLimitsUsageBuiltin() {
-	ast.RegisterBuiltin(updateLimitsUsageBuiltin)
+	ast.RegisterBuiltin(ratelimit.UpdateLimitsUsageBuiltin)
 
-	name := updateLimitsUsageBuiltin.Name
-	funcImpl := updateLimitsUsageBuiltinImpl
+	name := ratelimit.UpdateLimitsUsageBuiltin.Name
+	funcImpl := ratelimit.UpdateLimitsUsageBuiltinImpl
 
 	builtinFunc := func(bctx topdown.BuiltinContext, args []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := funcImpl(bctx)

--- a/pkg/ratelimit/limits_storage.go
+++ b/pkg/ratelimit/limits_storage.go
@@ -1,4 +1,4 @@
-package threescale
+package ratelimit
 
 import (
 	"fmt"

--- a/pkg/ratelimit/limits_storage_in_memory.go
+++ b/pkg/ratelimit/limits_storage_in_memory.go
@@ -1,4 +1,4 @@
-package threescale
+package ratelimit
 
 import (
 	"time"

--- a/pkg/ratelimit/limits_storage_redis.go
+++ b/pkg/ratelimit/limits_storage_redis.go
@@ -1,4 +1,4 @@
-package threescale
+package ratelimit
 
 import (
 	"strconv"

--- a/pkg/ratelimit/rate_limit_queries.go
+++ b/pkg/ratelimit/rate_limit_queries.go
@@ -1,4 +1,4 @@
-package threescale
+package ratelimit
 
 import (
 	"encoding/json"
@@ -45,7 +45,7 @@ var storage = newLimitsStorage()
 
 const limitsCtxKey = "limits_to_apply"
 
-var rateLimitBuiltin = &ast.Builtin{
+var RateLimitBuiltin = &ast.Builtin{
 	Name: "rate_limit",
 	Decl: types.NewFunction(types.Args(types.A), types.B),
 }
@@ -55,7 +55,7 @@ var rateLimitBuiltin = &ast.Builtin{
 // the context so it can be applied later. When rate-limited, it cleans the
 // limits in the context, because in that case, we want to make sure that no
 // updates are applied.
-func rateLimitBuiltinImpl(limitValue ast.Value, bctx topdown.BuiltinContext) (ast.Value, error) {
+func RateLimitBuiltinImpl(limitValue ast.Value, bctx topdown.BuiltinContext) (ast.Value, error) {
 	limit := opaLimit{}
 	err := ast.As(limitValue, &limit)
 	if err != nil {
@@ -81,14 +81,14 @@ func rateLimitBuiltinImpl(limitValue ast.Value, bctx topdown.BuiltinContext) (as
 	return ast.Boolean(!withinLimits), nil
 }
 
-var updateLimitsUsageBuiltin = &ast.Builtin{
+var UpdateLimitsUsageBuiltin = &ast.Builtin{
 	Name: "update_limits_usage",
 	Decl: types.NewFunction(types.Args(), types.B),
 }
 
 // Updates the counters used to rate-limit with the values stored in the
 // context.
-func updateLimitsUsageBuiltinImpl(bctx topdown.BuiltinContext) (ast.Value, error) {
+func UpdateLimitsUsageBuiltinImpl(bctx topdown.BuiltinContext) (ast.Value, error) {
 	limits, exists := bctx.Cache.Get(limitsCtxKey)
 
 	if !exists || limits == nil {

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1,4 +1,4 @@
-package threescale
+package request
 
 import "strings"
 
@@ -12,7 +12,7 @@ type Input struct {
 	Attributes  Attributes  `json:"attributes"`
 }
 
-func (input *Input) queryArgs() map[string]string {
+func (input *Input) QueryArgs() map[string]string {
 	res := make(map[string]string)
 
 	splittedPath := strings.Split(input.Attributes.Request.HTTP.Path, "?")


### PR DESCRIPTION
This PR organizes the code into packages: `threescale`, `ratelimit`, `queries` and `request`.